### PR TITLE
Fix: withSuspense helper returns component instead of JSX (issue #78)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,12 +60,14 @@ const LoadingFallback = () => (
 );
 
 // Helper function to wrap components with Suspense and LoadingFallback
-function withSuspense<T extends React.ComponentType<any>>(Component: T) {
-  return (
-    <Suspense fallback={<LoadingFallback />}>
-      <Component />
-    </Suspense>
-  );
+function withSuspense<T extends React.ComponentType<any>>(Component: T): React.ComponentType {
+  return function SuspenseWrapper(props: React.ComponentProps<T>) {
+    return (
+      <Suspense fallback={<LoadingFallback />}>
+        <Component {...props} />
+      </Suspense>
+    );
+  };
 }
 
 const router = createBrowserRouter([


### PR DESCRIPTION
## Summary

Fixed critical P0 bug #78 where  helper function was returning JSX directly instead of returning a React component.

## Problem
- Previous implementation executed function immediately and returned JSX
- Routes received JSX as element instead of component
- Could cause React #306 undefined component errors

## Solution
- Changed  to return a component function wrapper
- Props are now properly forwarded to lazy-loaded components
- All routes now correctly render with Suspense boundaries

## Testing
- All 303 tests passing
- Build successful
- No regressions