### PR TITLE
fix: add assets directory config to serve static files

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,6 +5,7 @@
 	"compatibility_date": "2025-04-24",
 	"compatibility_flags": ["nodejs_compat"],
 	"assets": {
+		"directory": "dist/client",
 		"not_found_handling": "single-page-application",
 		"run_worker_first": ["/api/*", "!/api/docs/*"]
 	},

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,6 +4,7 @@ compatibility_date = "2025-04-24"
 compatibility_flags = ["nodejs_compat"]
 
 [assets]
+directory = "dist/client"
 not_found_handling = "single-page-application"
 run_worker_first = ["/api/*", "!/api/docs/*"]
 


### PR DESCRIPTION
## Summary
- Add missing  field in wrangler assets configuration
- Fix blank white page issue on deployment by pointing Workers to the correct static assets location ()

## Root Cause
Cloudflare Workers needs  to know where to find the built static files (HTML, JS, CSS). Without this configuration, the frontend assets were not being served, resulting in a blank white page.